### PR TITLE
Add ARM support

### DIFF
--- a/src/typst/NOTES.md
+++ b/src/typst/NOTES.md
@@ -1,0 +1,9 @@
+## OS and Arch Support
+
+**For v0.3 and up**, ARM and AMD architectures are supported. Ubuntu and Debian images are tested in CI.
+
+### v0.1 and v0.2
+
+For versions 0.1 and 0.2, only AMD/x86 architecture is supported.
+
+"Older" Ubuntu versions (e.g. 20.04) may not work due to typst's glibc requirements (see [typst/typst#109](https://github.com/typst/typst/issues/109)). For these versions, run `ldd --version` to check the glibc version.

--- a/src/typst/devcontainer-feature.json
+++ b/src/typst/devcontainer-feature.json
@@ -9,6 +9,10 @@
             "type": "string",
             "proposals": [
                 "latest",
+                "0.5.0",
+                "0.4.0",
+                "0.3.0",
+                "0.2.0",
                 "0.1.0"
             ],
             "default": "latest",

--- a/src/typst/install.sh
+++ b/src/typst/install.sh
@@ -99,7 +99,7 @@ check_packages dpkg xz-utils
 
 architecture="$(dpkg --print-architecture)"
 # Typst has arm support starting at v0.3.0
-if [ "${architecture}" != "amd64" ] && ([ $TYPST_VERSION == '0.2.0'] || [ $TYPST_VERSION == '0.1.0']); then
+if [ "${architecture}" != "amd64" ] && ([ $TYPST_VERSION = '0.2.0' ] || [ $TYPST_VERSION = '0.1.0' ]); then
     echo "(!) Architecture $architecture unsupported for Typst version v$TYPST_VERSION!"
     exit 1
 fi

--- a/src/typst/install.sh
+++ b/src/typst/install.sh
@@ -98,7 +98,7 @@ export DEBIAN_FRONTEND=noninteractive
 check_packages dpkg xz-utils
 
 architecture="$(dpkg --print-architecture)"
-# Typst supports arm architecture after v0.3.0
+# Typst has arm support starting at v0.3.0
 if [ "${architecture}" != "amd64" ] && ([ $TYPST_VERSION == '0.2.0'] || [ $TYPST_VERSION == '0.1.0']); then
     echo "(!) Architecture $architecture unsupported for Typst version v$TYPST_VERSION!"
     exit 1

--- a/src/typst/install.sh
+++ b/src/typst/install.sh
@@ -142,8 +142,17 @@ find_version_from_git_tags TYPST_VERSION "https://github.com/typst/typst"
 
 check_packages curl ca-certificates
 echo "Downloading typst version ${TYPST_VERSION}..."
+
 mkdir -p /tmp/typst
-curl -sL "https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-${architecture}-unknown-linux-${LIBC_AND_EXTENSION}" | tar xJf - -C /tmp/typst
+curl -sL "https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-${architecture}-unknown-linux-${LIBC_AND_EXTENSION}" -o "/tmp/typst-${LIBC_AND_EXTENSION}"
+
+# we need tar extraction commands for the different extensions
+if [ $LIBC_AND_EXTENSION = "gnu.tar.gz" ]; then
+    tar xfz "/tmp/typst-${LIBC_AND_EXTENSION}" -C /tmp/typst
+else
+    tar xfJ "/tmp/typst-${LIBC_AND_EXTENSION}" -C /tmp/typst
+fi
+
 mv "/tmp/typst//typst-$(uname -m)-unknown-linux-musl/typst" /usr/local/bin/typst
 rm -rf /tmp/typst
 
@@ -151,3 +160,8 @@ rm -rf /tmp/typst
 cleanup
 
 echo "Done!"
+
+export TYPST_VERSION="0.2.0"
+export architecture="$(uname -m)"
+export LIBC_AND_EXTENSION="gnu.tar.gz"
+curl -sL "https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-${architecture}-unknown-linux-${LIBC_AND_EXTENSION}"

--- a/src/typst/install.sh
+++ b/src/typst/install.sh
@@ -129,7 +129,7 @@ elif ! exists_in_list "$SUPPORTED_ARCHS" " " $architecture; then
     echo "(!) Architecture $architecture unsupported for Typst version v$TYPST_VERSION!"
     exit 1
 else
-    echo "Arch test finished. Typst should be good to go!"
+    echo "Your platform architecture is supported by Typst version v$TYPST_VERSION!"
 fi
 
 # Soft version matching

--- a/src/typst/install.sh
+++ b/src/typst/install.sh
@@ -126,7 +126,7 @@ if [[ $TYPST_VERSION == '0.2'* ]] || [[ $TYPST_VERSION == '0.1'* ]]; then
     fi
     # typst only supports gnu libc for v0.1 and 0.2
     # Also, for these versions, the extension is `tar.gz`
-    LIBC="gnu" 
+    LIBC="gnu"
     EXTENSION="tar.gz"
 # check support for "newer" versions
 elif ! exists_in_list "$SUPPORTED_ARCHS" " " $architecture; then

--- a/src/typst/install.sh
+++ b/src/typst/install.sh
@@ -119,7 +119,7 @@ architecture="$(uname -m)"
 
 # check if the version starts with 0.2 or 0.1 ("older" versions)
 # https://stackoverflow.com/a/2172367
-if [ $TYPST_VERSION = '0.2.0' ] || [ $TYPST_VERSION = '0.1.0' ]; then
+if [[ $TYPST_VERSION == '0.2'* ]] || [[ $TYPST_VERSION == '0.1'* ]]; then
     if [[ "${architecture}" != "x86_64" ]]; then
         echo "(!) Architecture $architecture unsupported for older Typst version v$TYPST_VERSION!"
         exit 1

--- a/src/typst/install.sh
+++ b/src/typst/install.sh
@@ -126,7 +126,8 @@ if [[ $TYPST_VERSION == '0.2'* ]] || [[ $TYPST_VERSION == '0.1'* ]]; then
     fi
     # typst only supports gnu libc for v0.1 and 0.2
     # Also, for these versions, the extension is `tar.gz`
-    LIBC_AND_EXTENSION="gnu.tar.gz" 
+    LIBC="gnu" 
+    EXTENSION="tar.gz"
 # check support for "newer" versions
 elif ! exists_in_list "$SUPPORTED_ARCHS" " " $architecture; then
     echo "(!) Architecture $architecture unsupported for Typst version v$TYPST_VERSION!"
@@ -134,7 +135,8 @@ elif ! exists_in_list "$SUPPORTED_ARCHS" " " $architecture; then
 else
     echo "Your platform architecture is supported by Typst version v$TYPST_VERSION!"
     # (at least for version 0.3-0.5), typst uses musl, with `tar.xz` extension
-    LIBC_AND_EXTENSION="musl.tar.xz"
+    LIBC="musl"
+    EXTENSION="tar.xz"
 fi
 
 # Soft version matching
@@ -144,24 +146,20 @@ check_packages curl ca-certificates
 echo "Downloading typst version ${TYPST_VERSION}..."
 
 mkdir -p /tmp/typst
-curl -sL "https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-${architecture}-unknown-linux-${LIBC_AND_EXTENSION}" -o "/tmp/typst-${LIBC_AND_EXTENSION}"
+BIN_PATH="/tmp/typst-v${TYPST_VERSION}-${architecture}-${LIBC}-${EXTENSION}"
+curl -sL "https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-${architecture}-unknown-linux-${LIBC}.${EXTENSION}" -o "$BIN_PATH"
 
 # we need tar extraction commands for the different extensions
-if [ $LIBC_AND_EXTENSION = "gnu.tar.gz" ]; then
-    tar xfz "/tmp/typst-${LIBC_AND_EXTENSION}" -C /tmp/typst
+if [ $EXTENSION = "tar.gz" ]; then
+    tar xfz "$BIN_PATH" -C /tmp/typst
 else
-    tar xfJ "/tmp/typst-${LIBC_AND_EXTENSION}" -C /tmp/typst
+    tar xfJ "$BIN_PATH" -C /tmp/typst
 fi
 
-mv "/tmp/typst//typst-$(uname -m)-unknown-linux-musl/typst" /usr/local/bin/typst
+mv "/tmp/typst/typst-$(uname -m)-unknown-linux-${LIBC}/typst" /usr/local/bin/typst
 rm -rf /tmp/typst
 
 # Clean up
 cleanup
 
 echo "Done!"
-
-export TYPST_VERSION="0.2.0"
-export architecture="$(uname -m)"
-export LIBC_AND_EXTENSION="gnu.tar.gz"
-curl -sL "https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-${architecture}-unknown-linux-${LIBC_AND_EXTENSION}"

--- a/src/typst/install.sh
+++ b/src/typst/install.sh
@@ -93,15 +93,43 @@ find_version_from_git_tags() {
     echo "${variable_name}=${!variable_name}"
 }
 
+# https://www.baeldung.com/linux/check-variable-exists-in-list
+function exists_in_list() {
+    LIST=$1
+    DELIMITER=$2
+    VALUE=$3
+    LIST_WHITESPACES=`echo $LIST | tr "$DELIMITER" " "`
+    for x in $LIST_WHITESPACES; do
+        if [ "$x" = "$VALUE" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 export DEBIAN_FRONTEND=noninteractive
 
 check_packages dpkg xz-utils
 
-architecture="$(dpkg --print-architecture)"
-# Typst has arm support starting at v0.3.0
-if [ "${architecture}" != "amd64" ] && ([ $TYPST_VERSION = '0.2.0' ] || [ $TYPST_VERSION = '0.1.0' ]); then
+# supported architectures in version 0.3.0 and beyond (with musl)
+# Before 0.3.0, typst only supports x86_64
+SUPPORTED_ARCHS="aarch64 x86_64"
+
+architecture="$(uname -m)"
+
+# check if the version starts with 0.2 or 0.1 ("older" versions)
+# https://stackoverflow.com/a/2172367
+if [ $TYPST_VERSION = '0.2.0' ] || [ $TYPST_VERSION = '0.1.0' ]; then
+    if [[ "${architecture}" != "x86_64" ]]; then
+        echo "(!) Architecture $architecture unsupported for older Typst version v$TYPST_VERSION!"
+        exit 1
+    fi
+# check support for "newer" versions
+elif ! exists_in_list "$SUPPORTED_ARCHS" " " $architecture; then
     echo "(!) Architecture $architecture unsupported for Typst version v$TYPST_VERSION!"
     exit 1
+else
+    echo "Arch test finished. Typst should be good to go!"
 fi
 
 # Soft version matching
@@ -110,7 +138,7 @@ find_version_from_git_tags TYPST_VERSION "https://github.com/typst/typst"
 check_packages curl ca-certificates
 echo "Downloading typst version ${TYPST_VERSION}..."
 mkdir -p /tmp/typst
-curl -sL "https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-$(uname -m)-unknown-linux-musl.tar.xz" | tar xJf - -C /tmp/typst
+curl -sL "https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-${architecture}-unknown-linux-musl.tar.xz" | tar xJf - -C /tmp/typst
 mv "/tmp/typst//typst-$(uname -m)-unknown-linux-musl/typst" /usr/local/bin/typst
 rm -rf /tmp/typst
 

--- a/src/typst/install.sh
+++ b/src/typst/install.sh
@@ -97,9 +97,10 @@ export DEBIAN_FRONTEND=noninteractive
 
 check_packages dpkg xz-utils
 
-architecture="$(dpkg --print-architecture|grep -oP 'amd64')"
-if [ "${architecture}" != "amd64" ]; then
-    echo "(!) Architecture $architecture unsupported"
+architecture="$(dpkg --print-architecture)"
+# Typst supports arm architecture after v0.3.0
+if [ "${architecture}" != "amd64" ] && ([ $TYPST_VERSION == '0.2.0'] || [ $TYPST_VERSION == '0.1.0']); then
+    echo "(!) Architecture $architecture unsupported for Typst version v$TYPST_VERSION!"
     exit 1
 fi
 

--- a/src/typst/install.sh
+++ b/src/typst/install.sh
@@ -124,12 +124,17 @@ if [[ $TYPST_VERSION == '0.2'* ]] || [[ $TYPST_VERSION == '0.1'* ]]; then
         echo "(!) Architecture $architecture unsupported for older Typst version v$TYPST_VERSION!"
         exit 1
     fi
+    # typst only supports gnu libc for v0.1 and 0.2
+    # Also, for these versions, the extension is `tar.gz`
+    LIBC_AND_EXTENSION="gnu.tar.gz" 
 # check support for "newer" versions
 elif ! exists_in_list "$SUPPORTED_ARCHS" " " $architecture; then
     echo "(!) Architecture $architecture unsupported for Typst version v$TYPST_VERSION!"
     exit 1
 else
     echo "Your platform architecture is supported by Typst version v$TYPST_VERSION!"
+    # (at least for version 0.3-0.5), typst uses musl, with `tar.xz` extension
+    LIBC_AND_EXTENSION="musl.tar.xz"
 fi
 
 # Soft version matching
@@ -138,7 +143,7 @@ find_version_from_git_tags TYPST_VERSION "https://github.com/typst/typst"
 check_packages curl ca-certificates
 echo "Downloading typst version ${TYPST_VERSION}..."
 mkdir -p /tmp/typst
-curl -sL "https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-${architecture}-unknown-linux-musl.tar.xz" | tar xJf - -C /tmp/typst
+curl -sL "https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-${architecture}-unknown-linux-${LIBC_AND_EXTENSION}" | tar xJf - -C /tmp/typst
 mv "/tmp/typst//typst-$(uname -m)-unknown-linux-musl/typst" /usr/local/bin/typst
 rm -rf /tmp/typst
 

--- a/test/typst/javascript-node-0-18-latest.sh
+++ b/test/typst/javascript-node-0-18-latest.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+source dev-container-features-test-lib
+
+check "version" typst --version
+
+reportResults

--- a/test/typst/javascript-node-0-18.sh
+++ b/test/typst/javascript-node-0-18.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+source dev-container-features-test-lib
+
+check "version" typst --version
+
+reportResults

--- a/test/typst/javascript-node-0-18.sh
+++ b/test/typst/javascript-node-0-18.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -e
-
-source dev-container-features-test-lib
-
-check "version" typst --version
-
-reportResults

--- a/test/typst/javascript-node-18.sh
+++ b/test/typst/javascript-node-18.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+source dev-container-features-test-lib
+
+check "version" typst --version
+
+reportResults

--- a/test/typst/scenarios.json
+++ b/test/typst/scenarios.json
@@ -1,0 +1,18 @@
+{
+    "v0.2": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "typst": {
+                "version": "0.2.0"
+            }
+        }
+    },
+    "v0.5": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "typst": {
+                "version": "0.5.0"
+            }
+        }
+    }
+}

--- a/test/typst/scenarios.json
+++ b/test/typst/scenarios.json
@@ -21,12 +21,6 @@
             "typst": { "version": "0.2.0" }
         }
     },
-    "javascript-node-0-18": {
-        "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
-        "features": {
-            "typst": { "version": "0.2.0" }
-        }
-    },
     "javascript-node-0-18-latest": {
         "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
         "features": {

--- a/test/typst/scenarios.json
+++ b/test/typst/scenarios.json
@@ -14,5 +14,23 @@
                 "version": "0.5.0"
             }
         }
+    },
+    "javascript-node-18": {
+        "image": "mcr.microsoft.com/devcontainers/javascript-node:18",
+        "features": {
+            "typst": { "version": "0.2.0" }
+        }
+    },
+    "javascript-node-0-18": {
+        "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
+        "features": {
+            "typst": { "version": "0.2.0" }
+        }
+    },
+    "javascript-node-0-18-latest": {
+        "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
+        "features": {
+            "typst": {}
+        }
     }
 }

--- a/test/typst/v0.2.sh
+++ b/test/typst/v0.2.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+source dev-container-features-test-lib
+
+check "version" typst --version
+
+reportResults

--- a/test/typst/v0.5.sh
+++ b/test/typst/v0.5.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+source dev-container-features-test-lib
+
+check "version" typst --version
+
+reportResults


### PR DESCRIPTION
Closes #4 

This is a pretty quick fix to add arm support for versions above 0.2.0, although it doesn't check if the user has an architecture other than arm and amd. If you're fine with this, maybe we can add a short message to the NOTES.md going over supported architectures.

Maybe another way would be to check if `https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-$(uname -m)-unknown-linux-musl.tar.xz` is a valid url, and throwing an error if not. What do you think?